### PR TITLE
fix: datatables loading issue

### DIFF
--- a/ckanext/krzn/templates/base.html
+++ b/ckanext/krzn/templates/base.html
@@ -20,13 +20,14 @@
 We add the name of the organization as a css class which allows custom styles for
 different organizations/mandanten.
 #}
+{%- block htmltag -%}
+{% set lang = h.lang() %}
+<!--[if IE 9]> <html lang="{{ lang }}" class="ie9 {% if mandant %} mandant {% endif %}"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="{{ lang }}" {% if h.is_rtl_language()  %} dir="rtl" {% endif %} class="{% if mandant %} mandant {% endif %}"> <!--<![endif]-->
+{%- endblock -%}
 {% block bodytag %}
-{{- super() -}}
-class="
-{%- if mandant -%}
-	mandant
-{%- endif -%}
-" data-site-root="{{ h.url_for('/', locale='default', qualified=true) }}" data-locale-root="{{ h.url_for('/', qualified=true) }}" data-api-root="{{ g.api_url }}"
+{{ super() }}
+data-site-root="{{ h.url_for('/', locale='default', qualified=true) }}" data-locale-root="{{ h.url_for('/', qualified=true) }}" data-api-root="{{ g.api_url }}"
 {% if mandant %}
 	id="{{ mandant.name }}"
 {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-version = '0.3.1'
+version = '0.3.2'
 
 setuptools.setup(
     name='ckanext-krzn',


### PR DESCRIPTION
we're using bodytag to add the class mandant. but the extension datatables_view also adds a class to it which is important for it to work
our extension overwrites that class and therefore we need to move the mandant class evwen higher.
we're now doing htmltag which is not the best way since we're overwriting the whole htmltag not just adding to it but for now this seems like the best options. need to be more careful though when CKAN changes the htmltag implementation